### PR TITLE
Fix ffmpeg path prompt

### DIFF
--- a/Instagram_Encoder_Framework_FixV3.bat
+++ b/Instagram_Encoder_Framework_FixV3.bat
@@ -148,10 +148,15 @@ set "FFMPEG_CMD=ffmpeg"
 if errorlevel 1 (
     echo.
     echo === ATENCAO: ffmpeg nao encontrado no PATH. ===
-    set /p "FFMPEG_CMD_PATH=C:\ffmpeg\bin\ffmpeg.exe"
+    :loop_ffmpeg
+    set /p "FFMPEG_CMD_PATH=Digite o caminho completo do ffmpeg.exe: "
+    if "%FFMPEG_CMD_PATH%"=="" (
+        echo === ERRO: Caminho nao pode ser vazio. Tente novamente. ===
+        goto loop_ffmpeg
+    )
     if not exist "%FFMPEG_CMD_PATH%" (
-        echo === ERRO: Caminho do ffmpeg.exe invalido! Abortando. ===
-        exit /b 1
+        echo === ERRO: Caminho do ffmpeg.exe invalido! Tente novamente. ===
+        goto loop_ffmpeg
     )
     set "FFMPEG_CMD=%FFMPEG_CMD_PATH%"
 )


### PR DESCRIPTION
## Summary
- prompt user for ffmpeg.exe path in a loop until valid path is provided

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6840a46511c08332b796943bff2de925