### PR TITLE
Improve CRF input validation

### DIFF
--- a/Instagram_Encoder_Framework_FixV3.bat
+++ b/Instagram_Encoder_Framework_FixV3.bat
@@ -371,6 +371,13 @@ goto :ShowSummary_GetAdvancedParams :: Ou talvez um goto :EOF para sair com erro
     :: remove espacos em branco
     set "CRF_ESCOLHIDO=%CRF_ESCOLHIDO: =%"
 
+    :: garante que ha apenas digitos
+    echo %CRF_ESCOLHIDO% | findstr /R "^[0-9][0-9]*$" >nul
+    if errorlevel 1 (
+        echo === ERRO: Valor de CRF invalido. Digite apenas numeros. ===
+        goto loop_crf
+    )
+
     :: verifica se e numero inteiro
     set /a CRF_TEST=%CRF_ESCOLHIDO% >nul 2>&1
     if errorlevel 1 (


### PR DESCRIPTION
## Summary
- validate that CRF input contains only digits before numeric conversion

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6840a534be008332916d49ee1e3f5304